### PR TITLE
unmarshall number into correct int types

### DIFF
--- a/unmarshal.go
+++ b/unmarshal.go
@@ -55,6 +55,20 @@ func fillSqlScanner(structField interface{}, value interface{}) (sql.Scanner, er
 	return intf2, nil
 }
 
+// setFieldValue in a json object, there is only the number type, which defaults to float64. This method convertes float64 to the value
+// of the underlying struct field, for example uint64, or int32 etc...
+// If the field type is not one of the integers, it just sets the value
+func setFieldValue(field *reflect.Value, value reflect.Value) {
+	switch field.Type().Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		field.SetInt(int64(value.Float()))
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		field.SetUint(uint64(value.Float()))
+	default:
+		field.Set(value)
+	}
+}
+
 func unmarshalInto(ctx unmarshalContext, structType reflect.Type, sliceVal *reflect.Value) error {
 	// Read models slice
 	rootName := pluralize(jsonify(structType.Name()))
@@ -162,10 +176,10 @@ func unmarshalInto(ctx unmarshalContext, structType reflect.Type, sliceVal *refl
 
 								field.Set(reflect.ValueOf(scanner).Elem())
 							default:
-								field.Set(plainValue)
+								setFieldValue(&field, plainValue)
 							}
 						} else {
-							field.Set(plainValue)
+							setFieldValue(&field, plainValue)
 						}
 					}
 				}

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -2,8 +2,9 @@ package api2go
 
 import (
 	"database/sql"
-	"gopkg.in/guregu/null.v2/zero"
 	"time"
+
+	"gopkg.in/guregu/null.v2/zero"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -649,6 +650,78 @@ var _ = Describe("Unmarshal", func() {
 			Expect(err).To(BeNil())
 			Expect(len(zeroPosts)).To(Equal(1))
 			Expect(zeroPosts[0].Value).To(Equal(zero.NewFloat(2.3, true)))
+		})
+	})
+
+	Context("when unmarshalling objects with numbers", func() {
+		type NumberPost struct {
+			ID             string
+			Title          string
+			Number         int64
+			UnsignedNumber uint64
+		}
+
+		It("correctly converts number to int64", func() {
+			json := `
+				{
+					"numberPosts": [
+						{
+							"id": "test",
+							"title": "Blubb",
+							"number": 1337
+						}
+					]
+				}
+			`
+
+			var numberPosts []NumberPost
+
+			err := UnmarshalFromJSON([]byte(json), &numberPosts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(numberPosts)).To(Equal(1))
+			Expect(numberPosts[0].Number).To(Equal(int64(1337)))
+		})
+
+		It("correctly converts negative number to int64", func() {
+			json := `
+				{
+					"numberPosts": [
+						{
+							"id": "test",
+							"title": "Blubb",
+							"number": -1337
+						}
+					]
+				}
+			`
+
+			var numberPosts []NumberPost
+
+			err := UnmarshalFromJSON([]byte(json), &numberPosts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(numberPosts)).To(Equal(1))
+			Expect(numberPosts[0].Number).To(Equal(int64(-1337)))
+		})
+
+		It("correctly converts number to uint64", func() {
+			json := `
+				{
+					"numberPosts": [
+						{
+							"id": "test",
+							"title": "Blubb",
+							"unsignedNumber": 1337
+						}
+					]
+				}
+			`
+
+			var numberPosts []NumberPost
+
+			err := UnmarshalFromJSON([]byte(json), &numberPosts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(numberPosts)).To(Equal(1))
+			Expect(numberPosts[0].UnsignedNumber).To(Equal(uint64(1337)))
 		})
 	})
 })


### PR DESCRIPTION
there was a bug that unmarshalling of json numbers only worked with
float64. api2go now checks if the struct type is a int or uint type and
casts the number to that type.