### PR TITLE
latest specs from jsonapi.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ slices the values for you.
 Example Request
 GET /people?fields=id,name,age
 
-req["people"] contains values: ["id", "name", "age"]
+req.QueryParams["fields"] contains values: ["id", "name", "age"]
 ```
 
 ### Use Custom Controllers
@@ -183,19 +183,23 @@ will yield
 
 ```json
 {
-  "posts": [
+  "data": [
     {
       "id": "1",
-      "links": {"comments": ["1", "2"]},
+      "type": "posts",
+      "links": {
+        "comments": {
+          "ids": ["1", "2"],
+          "type": "comments"
+        },
+      },
       "title": "Foobar"
     }
   ],
-  "linked": {
-    "comments": [
-      {"id": "1", "text": "First!"},
-      {"id": "2", "text": "Second!"}
-    ]
-  }
+  "linked": [
+    {"id": "1", "type: "comments", "text": "First!"},
+    {"id": "2", "type: "comments", "text": "Second!"}
+  ]
 }
 ```
 

--- a/api.go
+++ b/api.go
@@ -304,7 +304,7 @@ func respondWith(obj interface{}, status int, w http.ResponseWriter) error {
 	if err != nil {
 		return err
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/vnd.api+json")
 	w.WriteHeader(status)
 	w.Write(data)
 	return nil
@@ -327,11 +327,7 @@ func unmarshalJSONRequest(r *http.Request) (map[string]interface{}, error) {
 func handleError(err error, w http.ResponseWriter) {
 	log.Println(err)
 	if e, ok := err.(HTTPError); ok {
-		if len(e.Errors) > 0 {
-			http.Error(w, marshalError(e), e.status)
-		} else {
-			http.Error(w, e.msg, e.status)
-		}
+		http.Error(w, marshalError(e), e.status)
 		return
 	}
 

--- a/api_test.go
+++ b/api_test.go
@@ -118,6 +118,7 @@ type CustomController struct{}
 
 var controllerErrorText = "exciting error"
 var controllerError = NewHTTPError(nil, controllerErrorText, http.StatusInternalServerError)
+var controllerErrorJSON = []byte(`{"errors":[{"status":"500","title":"exciting error"}]}`)
 
 func (ctrl *CustomController) FindAll(r *http.Request, objs *interface{}) error {
 	return controllerError
@@ -161,18 +162,21 @@ var _ = Describe("RestHandler", func() {
 
 			post1Json = map[string]interface{}{
 				"id":    "1",
+				"type":  "posts",
 				"title": "Hello, World!",
 				"value": nil,
 			}
 
 			post2Json = map[string]interface{}{
 				"id":    "2",
+				"type":  "posts",
 				"title": "I am NR. 2",
 				"value": nil,
 			}
 
 			post3Json = map[string]interface{}{
 				"id":    "3",
+				"type":  "posts",
 				"title": "I am NR. 3",
 				"value": nil,
 			}
@@ -191,7 +195,7 @@ var _ = Describe("RestHandler", func() {
 			var result map[string]interface{}
 			Expect(json.Unmarshal(rec.Body.Bytes(), &result)).To(BeNil())
 			Expect(result).To(Equal(map[string]interface{}{
-				"posts": []interface{}{post1Json, post2Json, post3Json},
+				"data": []interface{}{post1Json, post2Json, post3Json},
 			}))
 		})
 
@@ -203,7 +207,7 @@ var _ = Describe("RestHandler", func() {
 			var result map[string]interface{}
 			Expect(json.Unmarshal(rec.Body.Bytes(), &result)).To(BeNil())
 			Expect(result).To(Equal(map[string]interface{}{
-				"posts": post1Json,
+				"data": post1Json,
 			}))
 		})
 
@@ -215,7 +219,7 @@ var _ = Describe("RestHandler", func() {
 			var result map[string]interface{}
 			Expect(json.Unmarshal(rec.Body.Bytes(), &result)).To(BeNil())
 			Expect(result).To(Equal(map[string]interface{}{
-				"posts": []interface{}{post1Json, post2Json},
+				"data": []interface{}{post1Json, post2Json},
 			}))
 		})
 
@@ -224,7 +228,8 @@ var _ = Describe("RestHandler", func() {
 			Expect(err).To(BeNil())
 			api.Handler().ServeHTTP(rec, req)
 			Expect(rec.Code).To(Equal(http.StatusNotFound))
-			Expect(rec.Body.String()).To(Equal("post not found\n"))
+			errorJSON := []byte(`{"errors":[{"status":"404","title":"post not found"}]}`)
+			Expect(rec.Body.Bytes()).To(MatchJSON(errorJSON))
 		})
 
 		It("POSTSs new objects", func() {
@@ -237,8 +242,9 @@ var _ = Describe("RestHandler", func() {
 			var result map[string]interface{}
 			Expect(json.Unmarshal(rec.Body.Bytes(), &result)).To(BeNil())
 			Expect(result).To(Equal(map[string]interface{}{
-				"posts": map[string]interface{}{
+				"data": map[string]interface{}{
 					"id":    "4",
+					"type":  "posts",
 					"title": "New Post",
 					"value": nil,
 				},
@@ -335,7 +341,7 @@ var _ = Describe("RestHandler", func() {
 				Expect(err).To(BeNil())
 				api.Handler().ServeHTTP(rec, req)
 				Expect(rec.Code).To(Equal(http.StatusInternalServerError))
-				Expect(strings.TrimSpace(rec.Body.String())).To(Equal(controllerErrorText))
+				Expect(rec.Body.Bytes()).To(MatchJSON(controllerErrorJSON))
 			})
 
 			It("FindOne", func() {
@@ -343,7 +349,7 @@ var _ = Describe("RestHandler", func() {
 				Expect(err).To(BeNil())
 				api.Handler().ServeHTTP(rec, req)
 				Expect(rec.Code).To(Equal(http.StatusInternalServerError))
-				Expect(strings.TrimSpace(rec.Body.String())).To(Equal(controllerErrorText))
+				Expect(rec.Body.Bytes()).To(MatchJSON(controllerErrorJSON))
 			})
 
 			It("Create", func() {
@@ -352,7 +358,7 @@ var _ = Describe("RestHandler", func() {
 				Expect(err).To(BeNil())
 				api.Handler().ServeHTTP(rec, req)
 				Expect(rec.Code).To(Equal(http.StatusInternalServerError))
-				Expect(strings.TrimSpace(rec.Body.String())).To(Equal(controllerErrorText))
+				Expect(rec.Body.Bytes()).To(MatchJSON(controllerErrorJSON))
 			})
 
 			It("Delete", func() {
@@ -361,7 +367,7 @@ var _ = Describe("RestHandler", func() {
 				Expect(err).To(BeNil())
 				api.Handler().ServeHTTP(rec, req)
 				Expect(rec.Code).To(Equal(http.StatusInternalServerError))
-				Expect(strings.TrimSpace(rec.Body.String())).To(Equal(controllerErrorText))
+				Expect(rec.Body.Bytes()).To(MatchJSON(controllerErrorJSON))
 			})
 
 			It("Update", func() {
@@ -370,7 +376,7 @@ var _ = Describe("RestHandler", func() {
 				Expect(err).To(BeNil())
 				api.Handler().ServeHTTP(rec, req)
 				Expect(rec.Code).To(Equal(http.StatusInternalServerError))
-				Expect(strings.TrimSpace(rec.Body.String())).To(Equal(controllerErrorText))
+				Expect(rec.Body.Bytes()).To(MatchJSON(controllerErrorJSON))
 			})
 		})
 	})
@@ -445,12 +451,14 @@ var _ = Describe("RestHandler", func() {
 
 			post1JSON = map[string]interface{}{
 				"id":    "1",
+				"type":  "posts",
 				"title": "Hello, World!",
 				"value": nil,
 			}
 
 			post2JSON = map[string]interface{}{
 				"id":    "2",
+				"type":  "posts",
 				"title": "Hello, from second Post!",
 				"value": nil,
 			}
@@ -469,7 +477,7 @@ var _ = Describe("RestHandler", func() {
 			var result map[string]interface{}
 			Expect(json.Unmarshal(rec.Body.Bytes(), &result)).To(BeNil())
 			Expect(result).To(Equal(map[string]interface{}{
-				"posts": []interface{}{post1JSON, post2JSON},
+				"data": []interface{}{post1JSON, post2JSON},
 			}))
 		})
 
@@ -481,7 +489,7 @@ var _ = Describe("RestHandler", func() {
 			var result map[string]interface{}
 			Expect(json.Unmarshal(rec.Body.Bytes(), &result)).To(BeNil())
 			Expect(result).To(Equal(map[string]interface{}{
-				"posts": []interface{}{post1JSON},
+				"data": []interface{}{post1JSON},
 			}))
 		})
 

--- a/helpers.go
+++ b/helpers.go
@@ -46,6 +46,7 @@ var commonInitialisms = map[string]bool{
 	"UTF8":  true,
 	"VM":    true,
 	"XML":   true,
+	"JWT":   true,
 }
 
 // dejsonify returns a go struct key name from a JSON key name

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -71,11 +71,16 @@ func setFieldValue(field *reflect.Value, value reflect.Value) {
 
 func unmarshalInto(ctx unmarshalContext, structType reflect.Type, sliceVal *reflect.Value) error {
 	// Read models slice
-	rootName := pluralize(jsonify(structType.Name()))
 	var modelsInterface interface{}
+	rootName := pluralize(jsonify(structType.Name()))
+
 	if modelsInterface = ctx[rootName]; modelsInterface == nil {
-		return errors.New("expected root document to include a '" + rootName + "' key but it didn't.")
+		rootName = "data"
+		if modelsInterface = ctx[rootName]; modelsInterface == nil {
+			return errors.New("expected root document to include a '" + rootName + "' key but it didn't.")
+		}
 	}
+
 	models, ok := modelsInterface.([]interface{})
 	if !ok {
 		models = []interface{}{modelsInterface}
@@ -138,6 +143,9 @@ func unmarshalInto(ctx unmarshalContext, structType reflect.Type, sliceVal *refl
 				if err := setObjectID(val, id); err != nil {
 					return err
 				}
+
+			case "type":
+				// do not unmarshal the `type` field
 
 			default:
 				fieldName := dejsonify(k)


### PR DESCRIPTION
The latest specs for [json api](http://jsonapi.org/format/) state:

* Primary data MUST appear under a top-level key named "data".
* Error objects MUST appear under a top-level key named "errors".
* Linkage MUST be expressed as:
    * type and id members for to-one relationships. type is not required if the value of id is null.
    * type and ids members for homogeneous to-many relationships. type is not required if the value of ids is an empty array ([]).
    * A data member whose value is an array of objects each containing type and id members for heterogeneous to-many relationships.