### PR TITLE
Resource links

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,15 +221,16 @@ will yield
       "links": {
         "comments": {
           "ids": ["1", "2"],
-          "type": "comments"
-        },
+          "type": "comments",
+          "resource": "/posts/1/comments"
+        }
       },
       "title": "Foobar"
     }
   ],
   "linked": [
-    {"id": "1", "type: "comments", "text": "First!"},
-    {"id": "2", "type: "comments", "text": "Second!"}
+    {"id": "1", "type": "comments", "text": "First!"},
+    {"id": "2", "type": "comments", "text": "Second!"}
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ GET     /v1/posts/<id>
 PUT     /v1/posts/<id>
 DELETE  /v1/posts/<id>
 GET     /v1/posts/<id>,<id>,...
+GET     /v1/posts/<id>/comments
 ```
 
 #### Query Params
@@ -118,6 +119,36 @@ GET /people?fields=id,name,age
 
 req.QueryParams["fields"] contains values: ["id", "name", "age"]
 ```
+
+### Loading related resources
+Api2go always creates a `resource` property for elements in the `links` property of the result. This is like it's
+specified on jsonapi.org. Post example:
+
+```json
+{
+  "data": [
+    {
+      "id": "1",
+      "type": "posts",
+      "title": "Foobar",
+      "links": {
+        "comments": {
+          "resource": "/v1/posts/1/comments",
+          "ids": ["1", "2"],
+          "type": "comments",
+        }
+      }
+    }
+  ]
+}
+```
+
+If a client requests this `resource` url, the `FindAll` method of the comments resource will be called with a query
+parameter `postsID`.
+
+So if you implement the `FindAll` method, do not forget to check for all possible query Parameters. This means you have
+to check all your other structs and if it references the one for that you are implementing `FindAll`, check for the
+query Paramter and only return comments that belong to it. In this example, return the comments for the Post.
 
 ### Use Custom Controllers
 

--- a/marshal.go
+++ b/marshal.go
@@ -61,7 +61,7 @@ func Marshal(data interface{}) (interface{}, error) {
 	return marshal(data, "")
 }
 
-// MarshalPrefix does the same as Marshal but with additional fields with links like resource
+// MarshalPrefix does the same as Marshal but adds a prefix to generated URLs
 func MarshalPrefix(data interface{}, prefix string) (interface{}, error) {
 	return marshal(data, prefix)
 }
@@ -313,7 +313,7 @@ func MarshalToJSON(val interface{}) ([]byte, error) {
 	return json.Marshal(result)
 }
 
-// MarshalToJSONPrefix does the same as MarshalToJSON but with additional link fields like resource
+// MarshalToJSONPrefix does the same as MarshalToJSON but adds a prefix to generated URLs
 func MarshalToJSONPrefix(val interface{}, prefix string) ([]byte, error) {
 	result, err := marshal(val, prefix)
 	if err != nil {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -196,15 +196,15 @@ var _ = Describe("Marshalling", func() {
 						"links": map[string]interface{}{
 							"comments": map[string]interface{}{
 								// "self":     "/posts/1/links/comments",
-								// "resource": "/posts/1/comments",
-								"ids":  []interface{}{"1", "2"},
-								"type": "comments",
+								"resource": "/posts/1/comments",
+								"ids":      []interface{}{"1", "2"},
+								"type":     "comments",
 							},
 							"author": map[string]interface{}{
 								// "self":     "/posts/1/links/author",
-								// "resource": "/posts/1/author",
-								"id":   "1",
-								"type": "users",
+								"resource": "/posts/1/author",
+								"id":       "1",
+								"type":     "users",
 							},
 						},
 						"title": "Foobar",
@@ -214,16 +214,16 @@ var _ = Describe("Marshalling", func() {
 						"id": "2",
 						"links": map[string]interface{}{
 							"comments": map[string]interface{}{
-								// "self":     "/posts/1/links/comments",
-								// "resource": "/posts/1/comments",
-								"ids":  []interface{}{"1", "2"},
-								"type": "comments",
+								// "self":     "/posts/2/links/comments",
+								"resource": "/posts/2/comments",
+								"ids":      []interface{}{"1", "2"},
+								"type":     "comments",
 							},
 							"author": map[string]interface{}{
-								// "self":     "/posts/1/links/author",
-								// "resource": "/posts/1/author",
-								"id":   "1",
-								"type": "users",
+								// "self":     "/posts/2/links/author",
+								"resource": "/posts/2/author",
+								"id":       "1",
+								"type":     "users",
 							},
 						},
 						"title": "Foobarbarbar",
@@ -263,10 +263,14 @@ var _ = Describe("Marshalling", func() {
 					"title": "",
 					"links": map[string]interface{}{
 						"comments": map[string]interface{}{
-							"ids":  []interface{}{"1"},
-							"type": "comments",
+							"ids":      []interface{}{"1"},
+							"type":     "comments",
+							"resource": "/posts/1/comments",
 						},
-						"author": nil,
+						"author": map[string]interface{}{
+							"type":     "users",
+							"resource": "/posts/1/author",
+						},
 					},
 				},
 			}))
@@ -285,12 +289,14 @@ var _ = Describe("Marshalling", func() {
 					"title": "",
 					"links": map[string]interface{}{
 						"comments": map[string]interface{}{
-							"ids":  []interface{}{"1"},
-							"type": "comments",
+							"ids":      []interface{}{"1"},
+							"type":     "comments",
+							"resource": "/posts/1/comments",
 						},
 						"author": map[string]interface{}{
-							"id":   "1",
-							"type": "users",
+							"id":       "1",
+							"type":     "users",
+							"resource": "/posts/1/author",
 						},
 					},
 				},
@@ -325,8 +331,9 @@ var _ = Describe("Marshalling", func() {
 					"type": "anotherPosts",
 					"links": map[string]interface{}{
 						"author": map[string]interface{}{
-							"id":   "1",
-							"type": "users",
+							"id":       "1",
+							"type":     "users",
+							"resource": "/anotherPosts/1/author",
 						},
 					},
 				},
@@ -349,8 +356,9 @@ var _ = Describe("Marshalling", func() {
 					"type": "sqlTypesPosts",
 					"links": map[string]interface{}{
 						"author": map[string]interface{}{
-							"id":   "1",
-							"type": "users",
+							"id":       "1",
+							"type":     "users",
+							"resource": "/sqlTypesPosts/1/author",
 						},
 					},
 				},
@@ -373,8 +381,9 @@ var _ = Describe("Marshalling", func() {
 					"type": "sqlTypesPosts",
 					"links": map[string]interface{}{
 						"author": map[string]interface{}{
-							"id":   "1",
-							"type": "users",
+							"id":       "1",
+							"type":     "users",
+							"resource": "/sqlTypesPosts/1/author",
 						},
 					},
 				},
@@ -480,8 +489,9 @@ var _ = Describe("Marshalling", func() {
 					"text": "Will it ever work?",
 					"links": map[string]interface{}{
 						"inspiringQuestion": map[string]interface{}{
-							"id":   "1",
-							"type": "questions",
+							"id":       "1",
+							"type":     "questions",
+							"resource": "/questions/2/inspiringQuestion",
 						},
 					},
 				},
@@ -491,7 +501,10 @@ var _ = Describe("Marshalling", func() {
 						"type": "questions",
 						"text": "Does this test work?",
 						"links": map[string]interface{}{
-							"inspiringQuestion": nil,
+							"inspiringQuestion": map[string]interface{}{
+								"type":     "questions",
+								"resource": "/questions/1/inspiringQuestion",
+							},
 						},
 					},
 				},
@@ -511,8 +524,9 @@ var _ = Describe("Marshalling", func() {
 						"text": "It works now",
 						"links": map[string]interface{}{
 							"inspiringQuestion": map[string]interface{}{
-								"id":   "1",
-								"type": "questions",
+								"id":       "1",
+								"type":     "questions",
+								"resource": "/questions/3/inspiringQuestion",
 							},
 						},
 					},
@@ -522,8 +536,9 @@ var _ = Describe("Marshalling", func() {
 						"text": "Will it ever work?",
 						"links": map[string]interface{}{
 							"inspiringQuestion": map[string]interface{}{
-								"id":   "1",
-								"type": "questions",
+								"id":       "1",
+								"type":     "questions",
+								"resource": "/questions/2/inspiringQuestion",
 							},
 						},
 					},
@@ -534,7 +549,10 @@ var _ = Describe("Marshalling", func() {
 						"type": "questions",
 						"text": "Does this test work?",
 						"links": map[string]interface{}{
-							"inspiringQuestion": nil,
+							"inspiringQuestion": map[string]interface{}{
+								"type":     "questions",
+								"resource": "/questions/1/inspiringQuestion",
+							},
 						},
 					},
 				},

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -276,6 +276,30 @@ var _ = Describe("Marshalling", func() {
 			}))
 		})
 
+		It("marshal correctly with prefix", func() {
+			post := Post{ID: 1, Comments: []Comment{}, CommentsIDs: []int{1}}
+			i, err := MarshalPrefix(post, "/v1")
+			Expect(err).To(BeNil())
+			Expect(i).To(Equal(map[string]interface{}{
+				"data": map[string]interface{}{
+					"id":    "1",
+					"type":  "posts",
+					"title": "",
+					"links": map[string]interface{}{
+						"comments": map[string]interface{}{
+							"ids":      []interface{}{"1"},
+							"type":     "comments",
+							"resource": "/v1/posts/1/comments",
+						},
+						"author": map[string]interface{}{
+							"type":     "users",
+							"resource": "/v1/posts/1/author",
+						},
+					},
+				},
+			}))
+		})
+
 		It("prefers nested structs when given both, structs and IDs", func() {
 			comment := Comment{ID: 1}
 			author := User{ID: 1, Name: "Tester"}


### PR DESCRIPTION
This PR introduces the possibility to not specify any related IDs at all and just let a link be auto generated for the client to load related data. See http://jsonapi.org/format/#document-structure-resource-relationships

This introduces the `resource` member in the links object. The resource URL get's automatically generated by Marshalling a struct manually and via the API. For manually marshalling, I introduced 2 more methods to specify a API Prefix. This is now needed because before this feature, the serialisation had nothing to do with URLs. 

So, a new GET Route get's created for referenced structs now like `/v1/posts/1/comments`. If a client requests this URL, the request get's routed to the `FindAll` method of the Resource for `comments` with a Query parameter `PostsID` which in this example has the value 1.

Please let me know what you think about that. 

What I am wondering is whether it is to required to also include the hostname in the `resource` field for the URL. What we now also could easily implement is the `self` field. But I left that out for now, because we do not generate routes for relationships at the moment.