### PR TITLE
Introduce method to disable automatic redirects

### DIFF
--- a/api.go
+++ b/api.go
@@ -77,6 +77,16 @@ func NewAPI(prefix string) *API {
 	}
 }
 
+//SetRedirectTrailingSlash enables 307 redirects on urls ending with /
+//when disabled, an URL ending with / will 404
+func (api *API) SetRedirectTrailingSlash(enabled bool) {
+	if api.router == nil {
+		panic("router must not be nil")
+	}
+
+	api.router.RedirectTrailingSlash = enabled
+}
+
 // Request holds additional information for FindOne and Find Requests
 type Request struct {
 	QueryParams map[string][]string

--- a/api_test.go
+++ b/api_test.go
@@ -433,6 +433,24 @@ var _ = Describe("RestHandler", func() {
 			}))
 		})
 
+		It("POSTSs new objects with trailing slash automatic redirect enabled", func() {
+			reqBody := strings.NewReader(`{"posts": [{"title": "New Post"}]}`)
+			req, err := http.NewRequest("POST", "/posts/", reqBody)
+			Expect(err).To(BeNil())
+			api.SetRedirectTrailingSlash(true)
+			api.Handler().ServeHTTP(rec, req)
+			Expect(rec.Code).To(Equal(http.StatusTemporaryRedirect))
+		})
+
+		It("POSTSs new objects with trailing slash automatic redirect disabled", func() {
+			reqBody := strings.NewReader(`{"posts": [{"title": "New Post"}]}`)
+			req, err := http.NewRequest("POST", "/posts/", reqBody)
+			Expect(err).To(BeNil())
+			api.SetRedirectTrailingSlash(false)
+			api.Handler().ServeHTTP(rec, req)
+			Expect(rec.Code).To(Equal(http.StatusNotFound))
+		})
+
 		It("POSTSs multiple objects", func() {
 			reqBody := strings.NewReader(`{"posts": [{"title": "New Post"}, {"title" : "Second New Post"}]}`)
 			req, err := http.NewRequest("POST", "/posts", reqBody)


### PR DESCRIPTION
The default behaviour of api2go will be
307 on routes with trailing / but this feature can be
disabled

This provides the functionality wanted in #72 