### PR TITLE
Rename fields rc3

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,17 +139,33 @@ will yield
       "type": "posts",
       "links": {
         "comments": {
-          "ids": ["1", "2"],
-          "type": "comments",
-          "resource": "/posts/1/comments"
+          "linkage": [
+            {
+              "id": "1",
+              "type": "comments"
+            },
+            {
+              "id": "2",
+              "type": "comments"
+            }
+          ],
+          "resource": "\/posts\/1\/comments"
         }
       },
       "title": "Foobar"
     }
   ],
   "included": [
-    {"id": "1", "type": "comments", "text": "First!"},
-    {"id": "2", "type": "comments", "text": "Second!"}
+    {
+      "id": "1",
+      "type": "comments",
+      "text": "First!"
+    },
+    {
+      "id": "2",
+      "type": "comments",
+      "text": "Second!"
+    }
   ]
 }
 ```
@@ -268,9 +284,17 @@ specified on jsonapi.org. Post example:
       "title": "Foobar",
       "links": {
         "comments": {
-          "resource": "/v1/posts/1/comments",
-          "ids": ["1", "2"],
-          "type": "comments",
+          "resource": "\/v1\/posts\/1\/comments",
+          "linkage": [
+            {
+              "id": "1",
+              "type": "comments"
+            },
+            {
+              "id": "2",
+              "type": "comments"
+            }
+          ]
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ could also return an empty array, if there are currently no relations. This is w
 knows what is possible, even if nothing is referenced at the time.
 
 In addition to that, you can implement `MarshalIncludedRelations` which exports the complete referenced structs and embeds them in the json
-result inside the `linked` object.
+result inside the `included` object.
 
 We choose to do this because it gives you better flexibility and eliminates the conventions in the previous versions of api2go. **You can
 now choose how you internally manage relations.** So, there are no limits regarding the use of ORMs.
@@ -147,7 +147,7 @@ will yield
       "title": "Foobar"
     }
   ],
-  "linked": [
+  "included": [
     {"id": "1", "type": "comments", "text": "First!"},
     {"id": "2", "type": "comments", "text": "Second!"}
   ]

--- a/api_test.go
+++ b/api_test.go
@@ -366,8 +366,8 @@ var _ = Describe("RestHandler", func() {
 			api.Handler().ServeHTTP(rec, req)
 			Expect(rec.Code).To(Equal(http.StatusOK))
 			expected, err := json.Marshal(map[string]interface{}{
-				"data":   []map[string]interface{}{post1Json, post2Json, post3Json},
-				"linked": post1LinkedJSON,
+				"data":     []map[string]interface{}{post1Json, post2Json, post3Json},
+				"included": post1LinkedJSON,
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(rec.Body.Bytes()).To(MatchJSON(expected))
@@ -379,8 +379,8 @@ var _ = Describe("RestHandler", func() {
 			api.Handler().ServeHTTP(rec, req)
 			Expect(rec.Code).To(Equal(http.StatusOK))
 			expected, err := json.Marshal(map[string]interface{}{
-				"data":   post1Json,
-				"linked": post1LinkedJSON,
+				"data":     post1Json,
+				"included": post1LinkedJSON,
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(rec.Body.Bytes()).To(MatchJSON(expected))
@@ -392,8 +392,8 @@ var _ = Describe("RestHandler", func() {
 			api.Handler().ServeHTTP(rec, req)
 			Expect(rec.Code).To(Equal(http.StatusOK))
 			expected, err := json.Marshal(map[string]interface{}{
-				"data":   []interface{}{post1Json, post2Json},
-				"linked": post1LinkedJSON,
+				"data":     []interface{}{post1Json, post2Json},
+				"included": post1LinkedJSON,
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(rec.Body.Bytes()).To(MatchJSON(expected))

--- a/api_test.go
+++ b/api_test.go
@@ -297,6 +297,8 @@ var _ = Describe("RestHandler", func() {
 							"id":   "1",
 							"type": "users",
 						},
+						"self":    "/v1/posts/1/links/author",
+						"related": "/v1/posts/1/author",
 					},
 					"comments": map[string]interface{}{
 						"linkage": []map[string]interface{}{
@@ -305,6 +307,8 @@ var _ = Describe("RestHandler", func() {
 								"type": "comments",
 							},
 						},
+						"self":    "/v1/posts/1/links/comments",
+						"related": "/v1/posts/1/comments",
 					},
 				},
 			}
@@ -330,9 +334,13 @@ var _ = Describe("RestHandler", func() {
 				"links": map[string]interface{}{
 					"author": map[string]interface{}{
 						"linkage": nil,
+						"self":    "/v1/posts/2/links/author",
+						"related": "/v1/posts/2/author",
 					},
 					"comments": map[string]interface{}{
 						"linkage": []interface{}{},
+						"self":    "/v1/posts/2/links/comments",
+						"related": "/v1/posts/2/comments",
 					},
 				},
 			}
@@ -345,9 +353,13 @@ var _ = Describe("RestHandler", func() {
 				"links": map[string]interface{}{
 					"author": map[string]interface{}{
 						"linkage": nil,
+						"self":    "/v1/posts/3/links/author",
+						"related": "/v1/posts/3/author",
 					},
 					"comments": map[string]interface{}{
 						"linkage": []interface{}{},
+						"self":    "/v1/posts/3/links/comments",
+						"related": "/v1/posts/3/comments",
 					},
 				},
 			}
@@ -450,9 +462,13 @@ var _ = Describe("RestHandler", func() {
 					"links": map[string]interface{}{
 						"author": map[string]interface{}{
 							"linkage": nil,
+							"self":    "/v1/posts/4/links/author",
+							"related": "/v1/posts/4/author",
 						},
 						"comments": map[string]interface{}{
 							"linkage": []interface{}{},
+							"self":    "/v1/posts/4/links/comments",
+							"related": "/v1/posts/4/comments",
 						},
 					},
 				},
@@ -587,7 +603,7 @@ var _ = Describe("RestHandler", func() {
 		})
 	})
 
-	Context("Extracting query parameters", func() {
+	Context("Extracting query parameters with complete BaseURL API", func() {
 		var (
 			source    *fixtureSource
 			post1JSON map[string]interface{}
@@ -611,9 +627,13 @@ var _ = Describe("RestHandler", func() {
 				"links": map[string]interface{}{
 					"author": map[string]interface{}{
 						"linkage": nil,
+						"self":    "http://localhost:1337/v0/posts/1/links/author",
+						"related": "http://localhost:1337/v0/posts/1/author",
 					},
 					"comments": map[string]interface{}{
 						"linkage": []interface{}{},
+						"self":    "http://localhost:1337/v0/posts/1/links/comments",
+						"related": "http://localhost:1337/v0/posts/1/comments",
 					},
 				},
 			}
@@ -626,21 +646,26 @@ var _ = Describe("RestHandler", func() {
 				"links": map[string]interface{}{
 					"author": map[string]interface{}{
 						"linkage": nil,
+						"self":    "http://localhost:1337/v0/posts/2/links/author",
+						"related": "http://localhost:1337/v0/posts/2/author",
 					},
 					"comments": map[string]interface{}{
 						"linkage": []interface{}{},
+						"self":    "http://localhost:1337/v0/posts/2/links/comments",
+						"related": "http://localhost:1337/v0/posts/2/comments",
 					},
 				},
 			}
 
-			api = NewAPI("")
+			api = NewAPIWithBaseURL("v0", "http://localhost:1337")
+
 			api.AddResource(Post{}, source)
 
 			rec = httptest.NewRecorder()
 		})
 
 		It("FindAll returns 2 posts if no limit was set", func() {
-			req, err := http.NewRequest("GET", "/posts", nil)
+			req, err := http.NewRequest("GET", "/v0/posts", nil)
 			Expect(err).To(BeNil())
 			api.Handler().ServeHTTP(rec, req)
 			Expect(rec.Code).To(Equal(http.StatusOK))
@@ -652,7 +677,7 @@ var _ = Describe("RestHandler", func() {
 		})
 
 		It("FindAll returns 1 post with limit 1", func() {
-			req, err := http.NewRequest("GET", "/posts?limit=1", nil)
+			req, err := http.NewRequest("GET", "/v0/posts?limit=1", nil)
 			Expect(err).To(BeNil())
 			api.Handler().ServeHTTP(rec, req)
 			Expect(rec.Code).To(Equal(http.StatusOK))
@@ -664,7 +689,7 @@ var _ = Describe("RestHandler", func() {
 		})
 
 		It("Extracts multiple parameters correctly", func() {
-			req, err := http.NewRequest("GET", "/posts?sort=title,date", nil)
+			req, err := http.NewRequest("GET", "/v0/posts?sort=title,date", nil)
 			Expect(err).To(BeNil())
 
 			api2goReq := buildRequest(req)

--- a/api_test.go
+++ b/api_test.go
@@ -293,14 +293,18 @@ var _ = Describe("RestHandler", func() {
 				"value": nil,
 				"links": map[string]interface{}{
 					"author": map[string]interface{}{
-						"id":   "1",
-						"type": "users",
-						//"resource": "/v1/posts/1/author",
+						"linkage": map[string]interface{}{
+							"id":   "1",
+							"type": "users",
+						},
 					},
 					"comments": map[string]interface{}{
-						"ids":  []string{"1"},
-						"type": "comments",
-						//"resource": "/v1/posts/1/comments",
+						"linkage": []map[string]interface{}{
+							map[string]interface{}{
+								"id":   "1",
+								"type": "comments",
+							},
+						},
 					},
 				},
 			}
@@ -325,12 +329,10 @@ var _ = Describe("RestHandler", func() {
 				"value": nil,
 				"links": map[string]interface{}{
 					"author": map[string]interface{}{
-						"type": "users",
-						//"resource": "/v1/posts/2/author",
+						"linkage": nil,
 					},
 					"comments": map[string]interface{}{
-						"type": "comments",
-						//"resource": "/v1/posts/2/comments",
+						"linkage": []interface{}{},
 					},
 				},
 			}
@@ -342,12 +344,10 @@ var _ = Describe("RestHandler", func() {
 				"value": nil,
 				"links": map[string]interface{}{
 					"author": map[string]interface{}{
-						"type": "users",
-						//"resource": "/v1/posts/3/author",
+						"linkage": nil,
 					},
 					"comments": map[string]interface{}{
-						"type": "comments",
-						//"resource": "/v1/posts/3/comments",
+						"linkage": []interface{}{},
 					},
 				},
 			}
@@ -449,12 +449,10 @@ var _ = Describe("RestHandler", func() {
 					"value": nil,
 					"links": map[string]interface{}{
 						"author": map[string]interface{}{
-							"type": "users",
-							//"resource": "/v1/posts/4/author",
+							"linkage": nil,
 						},
 						"comments": map[string]interface{}{
-							"type": "comments",
-							//"resource": "/v1/posts/4/comments",
+							"linkage": []interface{}{},
 						},
 					},
 				},
@@ -612,12 +610,10 @@ var _ = Describe("RestHandler", func() {
 				"value": nil,
 				"links": map[string]interface{}{
 					"author": map[string]interface{}{
-						"type": "users",
-						//"resource": "/posts/1/author",
+						"linkage": nil,
 					},
 					"comments": map[string]interface{}{
-						"type": "comments",
-						//"resource": "/posts/1/comments",
+						"linkage": []interface{}{},
 					},
 				},
 			}
@@ -629,12 +625,10 @@ var _ = Describe("RestHandler", func() {
 				"value": nil,
 				"links": map[string]interface{}{
 					"author": map[string]interface{}{
-						"type": "users",
-						//"resource": "/posts/2/author",
+						"linkage": nil,
 					},
 					"comments": map[string]interface{}{
-						"type": "comments",
-						//"resource": "/posts/2/comments",
+						"linkage": []interface{}{},
 					},
 				},
 			}

--- a/examples/crud_example.go
+++ b/examples/crud_example.go
@@ -14,7 +14,7 @@
 // Create a chocolate with the name sweet
 // `curl -X POST http://localhost:31415/v0/chocolates -d '{"data" : [{"type" : "chocolates" , "name" : "Ritter Sport", "taste": "Very Good"}]}'`
 // Link the sweet
-// `curl -X POST http://localhost:31415/v0/users -d '{"data" : [{"type" : "users" , "username" : "marvin", "links": {"sweets": {"type": "chocolates", "ids": ["1"]}}}]}'`
+// `curl -X POST http://localhost:31415/v0/users -d '{"data" : [{"type" : "users" , "username" : "marvin", "links": {"sweets": {"linkage": {"type": "chocolates", "id": "1"}}}}]}'`
 package main
 
 import (
@@ -336,7 +336,7 @@ func (c *chocolateResource) Update(obj interface{}, r api2go.Request) error {
 }
 
 func main() {
-	api := api2go.NewAPI("v0")
+	api := api2go.NewAPIWithBaseURL("v0", "http://localhost:31415")
 	users := make(map[string]User)
 	chocStorage := ChocolateStorage{chocolates: make(map[string]Chocolate), idCount: 1}
 	api.AddResource(User{}, &userResource{users: users, chocStorage: &chocStorage})

--- a/jsonapi/integration_test.go
+++ b/jsonapi/integration_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Test for the public api of this package", func() {
 				},
 					"type" : "books"
 			},
-			"linked" : 
+			"included" : 
 				[ 
 					{ "id" : "A Magical UserID",
 						"name" : "Terry Pratchett",
@@ -166,7 +166,7 @@ var _ = Describe("Test for the public api of this package", func() {
 					}
 				}
 			},
-			"linked":
+			"included":
 				[
 					{"content":"First Page","id":"Page 1","type":"pages"},
 					{"content":"Second Page","id":"Page 2","type":"pages"},

--- a/jsonapi/integration_test.go
+++ b/jsonapi/integration_test.go
@@ -118,13 +118,27 @@ var _ = Describe("Test for the public api of this package", func() {
 				{ 
 						"author" : 
 						{
-							"id" : "A Magical UserID",
-							"type" : "stupidUsers"
+							"linkage": {
+								"id" : "A Magical UserID",
+								"type" : "stupidUsers"
+							}
 						},
 						"pages" : 
 						{ 
-							"ids" : [ "Page 1","Page 2","Page 3"],
-							"type" : "pages"
+							"linkage": [
+								{
+									"id": "Page 1",
+									"type": "pages"
+								},
+								{
+									"id": "Page 2",
+									"type": "pages"
+								},
+								{
+									"id": "Page 3",
+									"type": "pages"
+								}
+							]
 						}
 				},
 					"type" : "books"
@@ -157,22 +171,28 @@ var _ = Describe("Test for the public api of this package", func() {
 			"type":"books",
 			"links":{
 				"author":{
-					"id":"A Magical UserID",
-					"type":"users"
+					"linkage": {
+						"id":"A Magical UserID",
+						"type":"users"
+					}
 				},
 				"pages":{
-						"ids":["Page 1","Page 2","Page 3"],
-						"type": "pages"
-					}
+					"linkage": [
+						{
+							"id": "Page 1",
+							"type": "pages"
+						},
+						{
+							"id": "Page 2",
+							"type": "pages"
+						},
+						{
+							"id": "Page 3",
+							"type": "pages"
+						}
+					]}
 				}
-			},
-			"included":
-				[
-					{"content":"First Page","id":"Page 1","type":"pages"},
-					{"content":"Second Page","id":"Page 2","type":"pages"},
-					{"content":"Final page","id":"Page 3","type":"pages"},
-					{"id":"A Magical UserID","name":"Terry Pratchett","type":"users"}
-				]
+			}
 		}`
 
 	Context("Marshal and Unmarshal data", func() {

--- a/jsonapi/marshal.go
+++ b/jsonapi/marshal.go
@@ -238,23 +238,26 @@ func getStructLinks(relationer MarshalLinkedRelations, information ServerInforma
 
 	for referenceType, referenceIDs := range sortedResults {
 		name := referenceIDs[0].Name
-		// if referenceType is plural, we have ids, otherwise it's just one id
+		links[name] = map[string]interface{}{}
+		// if referenceType is plural, we need to use an array for linkage, otherwise it's just an object
 		if Pluralize(name) == name {
 			// multiple elements in links
-			var ids []string
+			linkage := []map[string]interface{}{}
 
 			for _, referenceID := range referenceIDs {
-				ids = append(ids, referenceID.ID)
+				linkage = append(linkage, map[string]interface{}{
+					"type": referenceType,
+					"id":   referenceID.ID,
+				})
 			}
 
-			links[name] = map[string]interface{}{
-				"ids":  ids,
-				"type": referenceType,
-			}
+			links[name]["linkage"] = linkage
 		} else {
 			links[name] = map[string]interface{}{
-				"id":   referenceIDs[0].ID,
-				"type": referenceType,
+				"linkage": map[string]interface{}{
+					"type": referenceType,
+					"id":   referenceIDs[0].ID,
+				},
 			}
 		}
 
@@ -268,9 +271,13 @@ func getStructLinks(relationer MarshalLinkedRelations, information ServerInforma
 	}
 
 	// check for empty references
-	for name, reference := range notIncludedReferences {
-		links[name] = map[string]interface{}{
-			"type": reference.Type,
+	for name := range notIncludedReferences {
+		links[name] = map[string]interface{}{}
+		// Plural empty relationships need an empty array and empty to-one need a null in the json
+		if Pluralize(name) == name {
+			links[name]["linkage"] = []interface{}{}
+		} else {
+			links[name]["linkage"] = nil
 		}
 		for key, value := range getLinksForServerInformation(relationer, name, information) {
 			links[name][key] = value

--- a/jsonapi/marshal.go
+++ b/jsonapi/marshal.go
@@ -145,7 +145,7 @@ func marshalSlice(data interface{}, information ServerInformation) (map[string]i
 	//data key is always present
 	result["data"] = dataElements
 	if includedElements != nil && len(includedElements) > 0 {
-		result["linked"] = includedElements
+		result["included"] = includedElements
 	}
 
 	return result, nil
@@ -334,13 +334,13 @@ func marshalStruct(data MarshalIdentifier, information ServerInformation) (map[s
 
 	included, ok := data.(MarshalIncludedRelations)
 	if ok {
-		linked, err := getIncludedStructs(included, information)
+		included, err := getIncludedStructs(included, information)
 		if err != nil {
 			return result, err
 		}
 
-		if len(linked) > 0 {
-			result["linked"] = linked
+		if len(included) > 0 {
+			result["included"] = included
 		}
 	}
 

--- a/jsonapi/marshal.go
+++ b/jsonapi/marshal.go
@@ -306,8 +306,8 @@ func getLinksForServerInformation(relationer MarshalLinkedRelations, name string
 			links["self"] = fmt.Sprintf("%s/%s/%s/links/%s", prefix, getStructType(relationer), relationer.GetID(), name)
 			links["related"] = fmt.Sprintf("%s/%s/%s/%s", prefix, getStructType(relationer), relationer.GetID(), name)
 		} else {
-			links["self"] = fmt.Sprintf("%s/%s/links/%s", getStructType(relationer), relationer.GetID(), name)
-			links["related"] = fmt.Sprintf("%s/%s/%s", getStructType(relationer), relationer.GetID(), name)
+			links["self"] = fmt.Sprintf("/%s/%s/links/%s", getStructType(relationer), relationer.GetID(), name)
+			links["related"] = fmt.Sprintf("/%s/%s/%s", getStructType(relationer), relationer.GetID(), name)
 		}
 	}
 

--- a/jsonapi/marshal_test.go
+++ b/jsonapi/marshal_test.go
@@ -164,14 +164,24 @@ var _ = Describe("Marshalling", func() {
 							"comments": map[string]interface{}{
 								"self":    completePrefix + "/posts/1/links/comments",
 								"related": completePrefix + "/posts/1/comments",
-								"ids":     []string{"1", "2"},
-								"type":    "comments",
+								"linkage": []map[string]interface{}{
+									map[string]interface{}{
+										"id":   "1",
+										"type": "comments",
+									},
+									map[string]interface{}{
+										"id":   "2",
+										"type": "comments",
+									},
+								},
 							},
 							"author": map[string]interface{}{
 								"self":    completePrefix + "/posts/1/links/author",
 								"related": completePrefix + "/posts/1/author",
-								"id":      "1",
-								"type":    "users",
+								"linkage": map[string]interface{}{
+									"id":   "1",
+									"type": "users",
+								},
 							},
 						},
 						"title": "Foobar",
@@ -183,14 +193,24 @@ var _ = Describe("Marshalling", func() {
 							"comments": map[string]interface{}{
 								"self":    completePrefix + "/posts/2/links/comments",
 								"related": completePrefix + "/posts/2/comments",
-								"ids":     []string{"1", "2"},
-								"type":    "comments",
+								"linkage": []map[string]interface{}{
+									map[string]interface{}{
+										"id":   "1",
+										"type": "comments",
+									},
+									map[string]interface{}{
+										"id":   "2",
+										"type": "comments",
+									},
+								},
 							},
 							"author": map[string]interface{}{
 								"self":    completePrefix + "/posts/2/links/author",
 								"related": completePrefix + "/posts/2/author",
-								"id":      "1",
-								"type":    "users",
+								"linkage": map[string]interface{}{
+									"id":   "1",
+									"type": "users",
+								},
 							},
 						},
 						"title": "Foobarbarbar",
@@ -229,13 +249,17 @@ var _ = Describe("Marshalling", func() {
 					"title": "",
 					"links": map[string]map[string]interface{}{
 						"comments": map[string]interface{}{
-							"ids":     []string{"1"},
-							"type":    "comments",
 							"self":    completePrefix + "/posts/1/links/comments",
 							"related": completePrefix + "/posts/1/comments",
+							"linkage": []map[string]interface{}{
+								map[string]interface{}{
+									"id":   "1",
+									"type": "comments",
+								},
+							},
 						},
 						"author": map[string]interface{}{
-							"type":    "users",
+							"linkage": nil,
 							"self":    completePrefix + "/posts/1/links/author",
 							"related": completePrefix + "/posts/1/author",
 						},
@@ -259,14 +283,18 @@ var _ = Describe("Marshalling", func() {
 					"title": "",
 					"links": map[string]map[string]interface{}{
 						"comments": map[string]interface{}{
-							"ids":  []string{"1"},
-							"type": "comments",
-							//"resource": "/posts/1/comments",
+							"linkage": []map[string]interface{}{
+								map[string]interface{}{
+									"id":   "1",
+									"type": "comments",
+								},
+							},
 						},
 						"author": map[string]interface{}{
-							"id":   "1",
-							"type": "users",
-							//"resource": "/posts/1/author",
+							"linkage": map[string]interface{}{
+								"id":   "1",
+								"type": "users",
+							},
 						},
 					},
 				},
@@ -295,9 +323,10 @@ var _ = Describe("Marshalling", func() {
 					"type": "anotherPosts",
 					"links": map[string]map[string]interface{}{
 						"author": map[string]interface{}{
-							"id":   "1",
-							"type": "users",
-							//"resource": "/anotherPosts/1/author",
+							"linkage": map[string]interface{}{
+								"id":   "1",
+								"type": "users",
+							},
 						},
 					},
 				},
@@ -373,9 +402,10 @@ var _ = Describe("Marshalling", func() {
 					"text": "Will it ever work?",
 					"links": map[string]map[string]interface{}{
 						"inspiringQuestion": map[string]interface{}{
-							"id":   "1",
-							"type": "questions",
-							//"resource": "/questions/2/inspiringQuestion",
+							"linkage": map[string]interface{}{
+								"id":   "1",
+								"type": "questions",
+							},
 						},
 					},
 				},
@@ -386,8 +416,7 @@ var _ = Describe("Marshalling", func() {
 						"text": "Does this test work?",
 						"links": map[string]map[string]interface{}{
 							"inspiringQuestion": map[string]interface{}{
-								"type": "questions",
-								//"resource": "/questions/1/inspiringQuestion",
+								"linkage": nil,
 							},
 						},
 					},
@@ -408,9 +437,10 @@ var _ = Describe("Marshalling", func() {
 						"text": "It works now",
 						"links": map[string]map[string]interface{}{
 							"inspiringQuestion": map[string]interface{}{
-								"id":   "1",
-								"type": "questions",
-								//"resource": "/questions/3/inspiringQuestion",
+								"linkage": map[string]interface{}{
+									"id":   "1",
+									"type": "questions",
+								},
 							},
 						},
 					},
@@ -420,9 +450,10 @@ var _ = Describe("Marshalling", func() {
 						"text": "Will it ever work?",
 						"links": map[string]map[string]interface{}{
 							"inspiringQuestion": map[string]interface{}{
-								"id":   "1",
-								"type": "questions",
-								//"resource": "/questions/2/inspiringQuestion",
+								"linkage": map[string]interface{}{
+									"id":   "1",
+									"type": "questions",
+								},
 							},
 						},
 					},
@@ -434,8 +465,7 @@ var _ = Describe("Marshalling", func() {
 						"text": "Does this test work?",
 						"links": map[string]map[string]interface{}{
 							"inspiringQuestion": map[string]interface{}{
-								"type": "questions",
-								//"resource": "/questions/1/inspiringQuestion",
+								"linkage": nil,
 							},
 						},
 					},
@@ -526,24 +556,32 @@ var _ = Describe("Marshalling", func() {
 		It("Generates to-one links correctly", func() {
 			links := getStructLinks(post, serverInformationNil)
 			Expect(links["author"]).To(Equal(map[string]interface{}{
-				"id":   "1",
-				"type": "users",
+				"linkage": map[string]interface{}{
+					"id":   "1",
+					"type": "users",
+				},
 			}))
 		})
 
 		It("Generates to-many links correctly", func() {
 			links := getStructLinks(post, serverInformationNil)
 			Expect(links["comments"]).To(Equal(map[string]interface{}{
-				"ids":  []string{"1"},
-				"type": "comments",
+				"linkage": []map[string]interface{}{
+					map[string]interface{}{
+						"id":   "1",
+						"type": "comments",
+					},
+				},
 			}))
 		})
 
 		It("Generates self/related URLs with baseURL and prefix correctly", func() {
 			links := getStructLinks(post, CompleteServerInformation{})
 			Expect(links["author"]).To(Equal(map[string]interface{}{
-				"id":      "1",
-				"type":    "users",
+				"linkage": map[string]interface{}{
+					"id":   "1",
+					"type": "users",
+				},
 				"self":    "http://my.domain/v1/posts/1/links/author",
 				"related": "http://my.domain/v1/posts/1/author",
 			}))
@@ -552,8 +590,10 @@ var _ = Describe("Marshalling", func() {
 		It("Generates self/related URLs with baseURL correctly", func() {
 			links := getStructLinks(post, BaseURLServerInformation{})
 			Expect(links["author"]).To(Equal(map[string]interface{}{
-				"id":      "1",
-				"type":    "users",
+				"linkage": map[string]interface{}{
+					"id":   "1",
+					"type": "users",
+				},
 				"self":    "http://my.domain/posts/1/links/author",
 				"related": "http://my.domain/posts/1/author",
 			}))
@@ -562,8 +602,10 @@ var _ = Describe("Marshalling", func() {
 		It("Generates self/related URLs with prefix correctly", func() {
 			links := getStructLinks(post, PrefixServerInformation{})
 			Expect(links["author"]).To(Equal(map[string]interface{}{
-				"id":      "1",
-				"type":    "users",
+				"linkage": map[string]interface{}{
+					"id":   "1",
+					"type": "users",
+				},
 				"self":    "/v1/posts/1/links/author",
 				"related": "/v1/posts/1/author",
 			}))

--- a/jsonapi/marshal_test.go
+++ b/jsonapi/marshal_test.go
@@ -197,7 +197,7 @@ var _ = Describe("Marshalling", func() {
 						"type":  "posts",
 					},
 				},
-				"linked": []map[string]interface{}{
+				"included": []map[string]interface{}{
 					map[string]interface{}{
 						"id":   "1",
 						"name": "Test Author",
@@ -270,7 +270,7 @@ var _ = Describe("Marshalling", func() {
 						},
 					},
 				},
-				"linked": []map[string]interface{}{
+				"included": []map[string]interface{}{
 					map[string]interface{}{
 						"id":   "1",
 						"type": "users",
@@ -365,7 +365,7 @@ var _ = Describe("Marshalling", func() {
 		question2 := Question{ID: "2", Text: "Will it ever work?", InspiringQuestionID: sql.NullString{String: "1", Valid: true}, InspiringQuestion: &question1}
 		question3 := Question{ID: "3", Text: "It works now", InspiringQuestionID: sql.NullString{String: "1", Valid: true}, InspiringQuestion: &question1Duplicate}
 
-		It("Correctly marshalls question2 and sets question1 into linked", func() {
+		It("Correctly marshalls question2 and sets question1 into included", func() {
 			expected := map[string]interface{}{
 				"data": map[string]interface{}{
 					"id":   "2",
@@ -379,7 +379,7 @@ var _ = Describe("Marshalling", func() {
 						},
 					},
 				},
-				"linked": []map[string]interface{}{
+				"included": []map[string]interface{}{
 					map[string]interface{}{
 						"id":   "1",
 						"type": "questions",
@@ -427,7 +427,7 @@ var _ = Describe("Marshalling", func() {
 						},
 					},
 				},
-				"linked": []map[string]interface{}{
+				"included": []map[string]interface{}{
 					map[string]interface{}{
 						"id":   "1",
 						"type": "questions",

--- a/jsonapi/unmarshal_test.go
+++ b/jsonapi/unmarshal_test.go
@@ -148,8 +148,12 @@ var _ = Describe("Unmarshal", func() {
 						"title": post.Title,
 						"links": map[string]interface{}{
 							"comments": map[string]interface{}{
-								"ids":  []interface{}{"1"},
-								"type": "links",
+								"linkage": []interface{}{
+									map[string]interface{}{
+										"id":   "1",
+										"type": "links",
+									},
+								},
 							},
 						},
 					},
@@ -171,8 +175,12 @@ var _ = Describe("Unmarshal", func() {
 						"title": post.Title,
 						"links": map[string]interface{}{
 							"comments": map[string]interface{}{
-								"ids":  []interface{}{"1"},
-								"type": "votes",
+								"linkage": []interface{}{
+									map[string]interface{}{
+										"id":   "1",
+										"type": "votes",
+									},
+								},
 							},
 						},
 					},
@@ -209,8 +217,10 @@ var _ = Describe("Unmarshal", func() {
 						"title": "Test",
 						"links": map[string]interface{}{
 							"author": map[string]interface{}{
-								"id":   "1",
-								"type": "users",
+								"linkage": map[string]interface{}{
+									"id":   "1",
+									"type": "users",
+								},
 							},
 						},
 					},
@@ -232,12 +242,22 @@ var _ = Describe("Unmarshal", func() {
 						"title": "Test",
 						"links": map[string]interface{}{
 							"author": map[string]interface{}{
-								"id":   "1",
-								"type": "users",
+								"linkage": map[string]interface{}{
+									"id":   "1",
+									"type": "users",
+								},
 							},
 							"comments": map[string]interface{}{
-								"ids":  []interface{}{"1", "2"},
-								"type": "comments",
+								"linkage": []interface{}{
+									map[string]interface{}{
+										"id":   "1",
+										"type": "comments",
+									},
+									map[string]interface{}{
+										"id":   "2",
+										"type": "comments",
+									},
+								},
 							},
 						},
 					},


### PR DESCRIPTION
this resolves #81 and #71 

I looked over jsonapi specs again and did not find any more fields that we have to rename. Apart from renaming we have to continue implementing the other features from the RC3 tickets.