### PR TITLE
new Route to fetch relations

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -401,6 +401,22 @@ var _ = Describe("RestHandler", func() {
 			Expect(rec.Body.Bytes()).To(MatchJSON(`{"data": [{"id": "1", "value": "This is a stupid post!", "type": "comments"}]}`))
 		})
 
+		It("GETs relationship data from relationship url for to-many", func() {
+			req, err := http.NewRequest("GET", "/v1/posts/1/links/comments", nil)
+			Expect(err).ToNot(HaveOccurred())
+			api.Handler().ServeHTTP(rec, req)
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(rec.Body.Bytes()).To(MatchJSON(`{"data": [{"id": "1", "type": "comments"}], "links": {"self": "/v1/posts/1/links/comments", "related": "/v1/posts/1/comments"}}`))
+		})
+
+		It("GETs relationship data from relationship url for to-one", func() {
+			req, err := http.NewRequest("GET", "/v1/posts/1/links/author", nil)
+			Expect(err).ToNot(HaveOccurred())
+			api.Handler().ServeHTTP(rec, req)
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(rec.Body.Bytes()).To(MatchJSON(`{"data": {"id": "1", "type": "users"}, "links": {"self": "/v1/posts/1/links/author", "related": "/v1/posts/1/author"}}`))
+		})
+
 		It("Gets 404 if a related struct was not found", func() {
 			req, err := http.NewRequest("GET", "/v1/posts/1/unicorns", nil)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
This fixes #83 

I did a small refactoring for handleLinked. Now the URLs for the router are all pre-generated with all possible relationships. This was necessary. Otherwise there was a conflict because of a previous dynamic segment. But apart form that, it is better that way. 

The new Route to load relations is still a single route with a dynamic segment that is the name of the relation. It would also be possible to pre-register a bunch of routes for that too.

The relationship routes are now "for-free". The FindOne resource methods are used for that too