### PR TITLE
recover from unmarshalling invalid types into fields

### DIFF
--- a/jsonapi/fixtures_test.go
+++ b/jsonapi/fixtures_test.go
@@ -66,6 +66,7 @@ func (u *User) SetID(stringID string) error {
 
 type SimplePost struct {
 	ID, Title, Text string
+	Size            int
 	Created         time.Time
 }
 

--- a/jsonapi/marshal_test.go
+++ b/jsonapi/marshal_test.go
@@ -26,6 +26,7 @@ var _ = Describe("Marshalling", func() {
 				"id":      "first",
 				"title":   firstPost.Title,
 				"text":    firstPost.Text,
+				"size":    0,
 				"created": created,
 			}
 
@@ -35,6 +36,7 @@ var _ = Describe("Marshalling", func() {
 				"id":      "second",
 				"title":   secondPost.Title,
 				"text":    secondPost.Text,
+				"size":    0,
 				"created": created,
 			}
 

--- a/jsonapi/unmarshal_test.go
+++ b/jsonapi/unmarshal_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Unmarshal", func() {
 		It("errors on non-array root", func() {
 			var posts []SimplePost
 			err := Unmarshal(map[string]interface{}{
-				"simplePosts": 42,
+				"data": 42,
 			}, &posts)
 			Expect(err).ToNot(BeNil())
 		})
@@ -93,7 +93,7 @@ var _ = Describe("Unmarshal", func() {
 		It("errors on non-documents", func() {
 			var posts []SimplePost
 			err := Unmarshal(map[string]interface{}{
-				"simplePosts": []interface{}{42},
+				"data": []interface{}{42},
 			}, &posts)
 			Expect(err).ToNot(BeNil())
 		})
@@ -101,13 +101,27 @@ var _ = Describe("Unmarshal", func() {
 		It("errors with wrong keys", func() {
 			var posts []SimplePost
 			err := Unmarshal(map[string]interface{}{
-				"simplePosts": []interface{}{
+				"data": []interface{}{
 					map[string]interface{}{
 						"foobar": 42,
 					},
 				},
 			}, &posts)
 			Expect(err).ToNot(BeNil())
+		})
+
+		It("errors with wrong type, expected int, got a string", func() {
+			var posts []SimplePost
+			err := Unmarshal(map[string]interface{}{
+				"data": []interface{}{
+					map[string]interface{}{
+						"text": "Gopher",
+						"size": "blubb",
+					},
+				},
+			}, &posts)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Could not set field 'Size'. Value 'blubb' had wrong type"))
 		})
 
 		It("errors with invalid time format", func() {


### PR DESCRIPTION
this fixes #103 

the panic is recovered and a proper error will be returned if an incoming field cannot be unmarshalled because it has a wrong type.