### PR TITLE
Relationship manipulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,25 @@ PATCH   /v1/posts/<id>
 DELETE  /v1/posts/<id>
 GET     /v1/posts/<id>/comments            // fetch referenced comments of a post
 GET     /v1/posts/<id>/links/comments      // fetch IDs of the referenced comments only
+PATCH   /v1/posts/<id>/links/comments      // replace all related comments
+
+// These 2 routes are only created for to-many relations that implement EditToManyRelations interface
+POST    /v1/posts/<id>/links/comments      // Add a new comment reference, only for to-many relations
+DELETE  /v1/posts/<id>/links/comments      // Delete a comment reference, only for to-many relations
 ```
+
+For the last two generated routes, it is necessary to implement the `jsonapi.EditToManyRelations` interface.
+
+```go
+type EditToManyRelations interface {
+	AddToManyIDs(name string, IDs []string) error
+	DeleteToManyIDs(name string, IDs []string) error
+}
+```
+
+All PATCH, POST and DELETE routes do a `FindOne` and update the values/relations in the previously found struct. This
+struct will then be passed on to the `Update` method of a resource struct. So you get all these routes "for free" and just
+have to implement the CRUD Update method.
 
 ### Query Params
 To support all the features mentioned in the `Fetching Resources` section of Jsonapi:

--- a/README.md
+++ b/README.md
@@ -125,11 +125,18 @@ We choose to do this because it gives you better flexibility and eliminates the 
 now choose how you internally manage relations.** So, there are no limits regarding the use of ORMs.
 
 ### Unmarshalling with references to other structs
-Incoming jsons can also contain reference IDs. In order to unmarshal them correctly, you have to implement the following interface
+Incoming jsons can also contain reference IDs. In order to unmarshal them correctly, you have to implement the following interfaces. If you only have to-one
+relationships, the `UnmarshalToOneRelations` interface is enough. 
 
 ```go
-type UnmarshalLinkedRelations interface {
-	SetReferencedIDs([]ReferenceID) error
+// UnmarshalToOneRelations must be implemented to unmarshal to-one relations
+type UnmarshalToOneRelations interface {
+	SetToOneReferenceID(name, ID string) error
+}
+
+// UnmarshalToManyRelations must be implemented to unmarshal to-many relations
+type UnmarshalToManyRelations interface {
+	SetToManyReferenceIDs(name string, IDs []string) error
 }
 ```
 

--- a/api.go
+++ b/api.go
@@ -667,12 +667,12 @@ func unmarshalJSONRequest(r *http.Request) (map[string]interface{}, error) {
 func handleError(err error, w http.ResponseWriter) {
 	log.Println(err)
 	if e, ok := err.(HTTPError); ok {
-		http.Error(w, marshalError(e), e.status)
+		writeResult(w, []byte(marshalError(e)), e.status)
 		return
 
 	}
 
-	http.Error(w, marshalError(err), http.StatusInternalServerError)
+	writeResult(w, []byte(marshalError(err)), http.StatusInternalServerError)
 }
 
 // Handler returns the http.Handler instance for the API.

--- a/examples/crud_example.go
+++ b/examples/crud_example.go
@@ -1,22 +1,30 @@
-// examples.go show how to implement a basic crud for one data structure with the api2go server functionality
-// to play with this example server you can for example run some of the following curl requests
+/*
+examples.go shows how to implement a basic CRUD for two data structures with the api2go server functionality.
+To play with this example server you can run some of the following curl requests
 
-// Create a new user:
-// `curl -X POST http://localhost:31415/v0/users -d '{"data" : [{"type" : "users" , "user-name" : "marvin"}]}'`
-// List users:
-// `curl -X GET http://localhost:31415/v0/users`
-// List paginated users:
-// `curl -X GET http://localhost:31415/v0/users?page[offset]=0&page[limit]=2`
-// OR
-// `curl -X GET http://localhost:31415/v0/users?page[number]=1&page[size]=2`
-// Update:
-// `curl -vX PATCH http://localhost:31415/v0/users/1 -d '{ "data" : {"type" : "users", "user-name" : "better marvin", "id" : "1"}}'`
-// Delete:
-// `curl -vX DELETE http://localhost:31415/v0/users/2`
-// Create a chocolate with the name sweet
-// `curl -X POST http://localhost:31415/v0/chocolates -d '{"data" : [{"type" : "chocolates" , "name" : "Ritter Sport", "taste": "Very Good"}]}'`
-// Link the sweet
-// `curl -X POST http://localhost:31415/v0/users -d '{"data" : [{"type" : "users" , "user-name" : "marvin", "links": {"sweets": {"linkage": {"type": "chocolates", "id": "1"}}}}]}'`
+Create a new user:
+	curl -X POST http://localhost:31415/v0/users -d '{"data" : [{"type" : "users" , "user-name" : "marvin"}]}'
+
+List users:
+	curl -X GET http://localhost:31415/v0/users
+
+List paginated users:
+	curl -X GET http://localhost:31415/v0/users?page[offset]=0&page[limit]=2
+OR
+	curl -X GET http://localhost:31415/v0/users?page[number]=1&page[size]=2
+
+Update:
+	curl -vX PATCH http://localhost:31415/v0/users/1 -d '{ "data" : {"type" : "users", "user-name" : "better marvin", "id" : "1"}}'
+
+Delete:
+	curl -vX DELETE http://localhost:31415/v0/users/2
+
+Create a chocolate with the name sweet
+	curl -X POST http://localhost:31415/v0/chocolates -d '{"data" : [{"type" : "chocolates" , "name" : "Ritter Sport", "taste": "Very Good"}]}'
+
+Link the sweet
+	curl -X POST http://localhost:31415/v0/users -d '{"data" : [{"type" : "users" , "user-name" : "marvin", "links": {"sweets": {"linkage": {"type": "chocolates", "id": "1"}}}}]}'
+*/
 package main
 
 import (

--- a/examples/crud_example.go
+++ b/examples/crud_example.go
@@ -87,15 +87,13 @@ func (u User) GetReferencedStructs() []jsonapi.MarshalIdentifier {
 	return result
 }
 
-// SetReferencedIDs to satisfy the jsonapi.UnmarshalLinkedRelations interface
-func (u *User) SetReferencedIDs(references []jsonapi.ReferenceID) error {
-	for _, reference := range references {
-		if reference.Name == "sweets" {
-			u.ChocolatesIDs = append(u.ChocolatesIDs, reference.ID)
-		}
+// SetToManyReferenceIDs sets the sweets reference IDs and satisfies the jsonapi.UnmarshalToManyRelations interface
+func (u *User) SetToManyReferenceIDs(name string, IDs []string) error {
+	if name == "sweets" {
+		u.ChocolatesIDs = IDs
 	}
 
-	return nil
+	return errors.New("There is no to-many relationship with the name " + name)
 }
 
 // Chocolate is the chocolate that a user consumes in order to get fat and happy

--- a/jsonapi/fixtures_test.go
+++ b/jsonapi/fixtures_test.go
@@ -2,6 +2,7 @@ package jsonapi
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -115,6 +116,38 @@ func (c Post) GetReferences() []Reference {
 			Name: "author",
 		},
 	}
+}
+
+func (c *Post) SetToOneReferenceID(name, ID string) error {
+	if name == "author" {
+		intID, err := strconv.ParseInt(ID, 10, 64)
+		if err != nil {
+			return err
+		}
+		c.AuthorID = sql.NullInt64{Valid: true, Int64: intID}
+
+		return nil
+	}
+
+	return errors.New("There is no to-one relationship named " + name)
+}
+
+func (c *Post) SetToManyReferenceIDs(name string, IDs []string) error {
+	if name == "comments" {
+		commentsIDs := []int{}
+		for _, ID := range IDs {
+			intID, err := strconv.ParseInt(ID, 10, 64)
+			if err != nil {
+				return err
+			}
+			commentsIDs = append(commentsIDs, int(intID))
+		}
+		c.CommentsIDs = commentsIDs
+
+		return nil
+	}
+
+	return errors.New("There is no to-many relationship named " + name)
 }
 
 func (c *Post) SetReferencedIDs(ids []ReferenceID) error {

--- a/jsonapi/integration_test.go
+++ b/jsonapi/integration_test.go
@@ -1,6 +1,8 @@
 package jsonapi
 
 import (
+	"errors"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -48,17 +50,24 @@ func (b Book) GetReferencedIDs() []ReferenceID {
 	return result
 }
 
-func (b *Book) SetReferencedIDs(IDs []ReferenceID) error {
-	for _, reference := range IDs {
-		switch reference.Name {
-		case "author":
-			b.AuthorID = reference.ID
-		case "pages":
-			b.PagesIDs = append(b.PagesIDs, reference.ID)
-		}
+func (b *Book) SetToOneReferenceID(name, ID string) error {
+	if name == "author" {
+		b.AuthorID = ID
+
+		return nil
 	}
 
-	return nil
+	return errors.New("There is no to-one relationship with name " + name)
+}
+
+func (b *Book) SetToManyReferenceIDs(name string, IDs []string) error {
+	if name == "pages" {
+		b.PagesIDs = IDs
+
+		return nil
+	}
+
+	return errors.New("There is no to-many relationship with name " + name)
 }
 
 func (b Book) GetReferencedStructs() []MarshalIdentifier {

--- a/jsonapi/unmarshal.go
+++ b/jsonapi/unmarshal.go
@@ -24,6 +24,56 @@ type UnmarshalToManyRelations interface {
 	SetToManyReferenceIDs(name string, IDs []string) error
 }
 
+// The EditToManyRelations interface can be optionally implemented to add and delete to-many
+// relationships on a already unmarshalled struct. These methods are used by our API for the to-many
+// relationship update routes.
+/*
+There are 3 HTTP Methods to edit to-many relations:
+
+	PATCH /v1/posts/1/comments
+	Content-Type: application/vnd.api+json
+	Accept: application/vnd.api+json
+
+	{
+	  "data": [
+		{ "type": "comments", "id": "2" },
+		{ "type": "comments", "id": "3" }
+	  ]
+	}
+
+this replaces all of the comments that belong to post with ID 1 and the SetToManyReferenceIDs method
+will be called
+
+	POST /v1/posts/1/comments
+	Content-Type: application/vnd.api+json
+	Accept: application/vnd.api+json
+
+	{
+	  "data": [
+		{ "type": "comments", "id": "123" }
+	  ]
+	}
+
+adds a new comment to the post with ID 1. The AddToManyIDs methid will be called.
+
+	DELETE /v1/posts/1/comments
+	Content-Type: application/vnd.api+json
+	Accept: application/vnd.api+json
+
+	{
+	  "data": [
+		{ "type": "comments", "id": "12" },
+		{ "type": "comments", "id": "13" }
+	  ]
+	}
+
+deletes comments that belong to post with ID 1. The DeleteToManyIDs method will be called.
+*/
+type EditToManyRelations interface {
+	AddToManyIDs(name, IDs []string) error
+	DeleteToManyIDs(name, IDs []string) error
+}
+
 // Unmarshal reads a JSONAPI map to a model struct
 // target must at least implement the `UnmarshalIdentifier` interface.
 func Unmarshal(input map[string]interface{}, target interface{}) error {

--- a/jsonapi/unmarshal.go
+++ b/jsonapi/unmarshal.go
@@ -319,6 +319,14 @@ func unmarshalLinks(val reflect.Value, linksMap map[string]interface{}) error {
 			}
 
 			target.SetToOneReferenceID(linkName, hasOneID)
+		} else if links["linkage"] == nil {
+			// this means that a to-one relationship must be deleted
+			target, ok := val.Interface().(UnmarshalToOneRelations)
+			if !ok {
+				return errors.New("target struct must implement interface UnmarshalToOneRelations")
+			}
+
+			target.SetToOneReferenceID(linkName, "")
 		} else {
 			hasMany, ok := links["linkage"].([]interface{})
 			if !ok {

--- a/jsonapi/unmarshal.go
+++ b/jsonapi/unmarshal.go
@@ -70,8 +70,8 @@ adds a new comment to the post with ID 1. The AddToManyIDs methid will be called
 deletes comments that belong to post with ID 1. The DeleteToManyIDs method will be called.
 */
 type EditToManyRelations interface {
-	AddToManyIDs(name, IDs []string) error
-	DeleteToManyIDs(name, IDs []string) error
+	AddToManyIDs(name string, IDs []string) error
+	DeleteToManyIDs(name string, IDs []string) error
 }
 
 // Unmarshal reads a JSONAPI map to a model struct
@@ -288,6 +288,13 @@ func setFieldValue(field *reflect.Value, value reflect.Value) (err error) {
 	return nil
 }
 
+// UnmarshalLinkage is used by api2go.API to only unmarshal references inside a linkage object.
+// The target interface must implement UnmarshalToOneRelations or UnmarshalToManyRelations interface.
+// The linksMap is the content of the linkage object from the json
+func UnmarshalLinkage(target interface{}, name string, links interface{}) error {
+	return processLinkage(links, name, target)
+}
+
 func unmarshalLinks(val reflect.Value, linksMap map[string]interface{}) error {
 	for linkName, links := range linksMap {
 		links, ok := links.(map[string]interface{})
@@ -306,56 +313,64 @@ func unmarshalLinks(val reflect.Value, linksMap map[string]interface{}) error {
 			val = val.Addr()
 		}
 
-		hasOne, ok := links["linkage"].(map[string]interface{})
-		if ok {
-			hasOneID, ok := hasOne["id"].(string)
-			if !ok {
-				return fmt.Errorf("linkage object must have a field id for %s", linkName)
-			}
-
-			target, ok := val.Interface().(UnmarshalToOneRelations)
-			if !ok {
-				return errors.New("target struct must implement interface UnmarshalToOneRelations")
-			}
-
-			target.SetToOneReferenceID(linkName, hasOneID)
-		} else if links["linkage"] == nil {
-			// this means that a to-one relationship must be deleted
-			target, ok := val.Interface().(UnmarshalToOneRelations)
-			if !ok {
-				return errors.New("target struct must implement interface UnmarshalToOneRelations")
-			}
-
-			target.SetToOneReferenceID(linkName, "")
-		} else {
-			hasMany, ok := links["linkage"].([]interface{})
-			if !ok {
-				fmt.Printf("%#v", links["linkage"])
-				return fmt.Errorf("invalid linkage object or array, must be an object with \"id\" and \"type\" field for %s", linkName)
-			}
-
-			target, ok := val.Interface().(UnmarshalToManyRelations)
-			if !ok {
-				return errors.New("target struct must implement interface UnmarshalToManyRelations")
-			}
-
-			hasManyIDs := []string{}
-
-			for _, entry := range hasMany {
-				linkage, ok := entry.(map[string]interface{})
-				if !ok {
-					return fmt.Errorf("entry in linkage array must be an object for %s", linkName)
-				}
-				linkageID, ok := linkage["id"].(string)
-				if !ok {
-					return fmt.Errorf("all linkage objects must have a field id for %s", linkName)
-				}
-
-				hasManyIDs = append(hasManyIDs, linkageID)
-			}
-
-			target.SetToManyReferenceIDs(linkName, hasManyIDs)
+		err := processLinkage(links["linkage"], linkName, val.Interface())
+		if err != nil {
+			return err
 		}
+	}
+
+	return nil
+}
+
+func processLinkage(linkage interface{}, linkName string, target interface{}) error {
+	hasOne, ok := linkage.(map[string]interface{})
+	if ok {
+		hasOneID, ok := hasOne["id"].(string)
+		if !ok {
+			return fmt.Errorf("linkage object must have a field id for %s", linkName)
+		}
+
+		target, ok := target.(UnmarshalToOneRelations)
+		if !ok {
+			return errors.New("target struct must implement interface UnmarshalToOneRelations")
+		}
+
+		target.SetToOneReferenceID(linkName, hasOneID)
+	} else if linkage == nil {
+		// this means that a to-one relationship must be deleted
+		target, ok := target.(UnmarshalToOneRelations)
+		if !ok {
+			return errors.New("target struct must implement interface UnmarshalToOneRelations")
+		}
+
+		target.SetToOneReferenceID(linkName, "")
+	} else {
+		hasMany, ok := linkage.([]interface{})
+		if !ok {
+			return fmt.Errorf("invalid linkage object or array, must be an object with \"id\" and \"type\" field for %s", linkName)
+		}
+
+		target, ok := target.(UnmarshalToManyRelations)
+		if !ok {
+			return errors.New("target struct must implement interface UnmarshalToManyRelations")
+		}
+
+		hasManyIDs := []string{}
+
+		for _, entry := range hasMany {
+			linkage, ok := entry.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("entry in linkage array must be an object for %s", linkName)
+			}
+			linkageID, ok := linkage["id"].(string)
+			if !ok {
+				return fmt.Errorf("all linkage objects must have a field id for %s", linkName)
+			}
+
+			hasManyIDs = append(hasManyIDs, linkageID)
+		}
+
+		target.SetToManyReferenceIDs(linkName, hasManyIDs)
 	}
 
 	return nil


### PR DESCRIPTION
This implements #80.

The huge brainfuck in this code is again reflections and interfaces. Very often a stupid trick is used to get an addressable value of an `interface{}` by using a slice. Because with a slice it is possible to get a pointer to an `interface{}` type via reflection...

But the feature works

Todos:
- [x] Documentation
- [x] Update example