### PR TITLE
Method to get instance of julienschmidt httprouter

### DIFF
--- a/api.go
+++ b/api.go
@@ -679,3 +679,8 @@ func handleError(err error, w http.ResponseWriter) {
 func (api *API) Handler() http.Handler {
 	return api.router
 }
+
+// Router can be used instead of Handler() to get the instance of julienschmidt httprouter.
+func (api *API) Router() *httprouter.Router {
+	return api.router
+}


### PR DESCRIPTION
The idea came up in #106. You can now choose to get a Standard go
Handler or the underlying router instance to further customize api2go
with more routes.

This resolves #106 