### PR TITLE
Sql null types

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ go get github.com/univedo/api2go/jsonapi
   - [Unmarshalling with references to other structs](#unmarshalling-with-references-to-other-structs)
 - [Ignoring fields](#ignoring-fields)
 - [Manual marshaling / unmarshaling](#manual-marshaling--unmarshaling)
+- [SQL Null-Types](#sql-null-types)
 - [Building a REST API](#building-a-rest-api)
   - [Query Params](#query-params)
   - [Using Pagination](#using-pagination)
@@ -208,6 +209,20 @@ var posts []Post
 err := jsonapi.UnmarshalFromJSON(json, &posts)
 // posts[0] == Post{ID: 1, Title: "Foobar", CommentsIDs: []int{1, 2}}
 ```
+
+## SQL Null-Types
+When using a SQL Database it is most likely you want to use the special SQL-Types from the `database/sql` package. These are
+
+- sql.NullBool
+- sql.NullFloat64
+- sql.NullInt64
+- sql.NullString
+
+The Problem is, that they internally manage the `null` value behavior by using a custom struct. In order to Marshal und Unmarshal
+these values, it is required to implement the `json.Marshaller` and `json.Unmarshaller` interfaces of the go standard library.
+
+But you dont have to do this by yourself! There already is a library that did the work for you. We recommend that you use the types
+of this library: http://gopkg.in/guregu/null.v2/zero
 
 ## Building a REST API
 

--- a/jsonapi/fixtures_test.go
+++ b/jsonapi/fixtures_test.go
@@ -325,6 +325,23 @@ func (n *NumberPost) SetID(ID string) error {
 	return nil
 }
 
+type SqlNullPost struct {
+	ID     string
+	Title  zero.String
+	Likes  zero.Int
+	Rating zero.Float
+	IsCool zero.Bool
+}
+
+func (s SqlNullPost) GetID() string {
+	return s.ID
+}
+
+func (s *SqlNullPost) SetID(ID string) error {
+	s.ID = ID
+	return nil
+}
+
 type CompleteServerInformation struct{}
 
 const completePrefix = "http://my.domain/v1"

--- a/jsonapi/marshal_test.go
+++ b/jsonapi/marshal_test.go
@@ -650,4 +650,37 @@ var _ = Describe("Marshalling", func() {
 			Expect(len(actual)).To(Equal(len(expected)))
 		})
 	})
+
+	// In order to use the SQL Null-Types the Marshal/Unmarshal interfaces for these types must be implemented.
+	// The library "gopkg.in/guregu/null.v2/zero" can be used for that.
+	Context("SQL Null-Types", func() {
+		var nullPost SqlNullPost
+
+		BeforeEach(func() {
+			nullPost = SqlNullPost{
+				ID:     "theID",
+				Title:  zero.StringFrom("Test"),
+				Likes:  zero.IntFrom(666),
+				Rating: zero.FloatFrom(66.66),
+				IsCool: zero.BoolFrom(true),
+			}
+		})
+
+		It("correctly marshalls String, Int64, Float64 and Bool", func() {
+			result, err := MarshalToJSON(nullPost)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(MatchJSON(`
+				{
+					"data": {
+						"id": "theID",
+						"title": "Test",
+						"likes": 666,
+						"rating": 66.66,
+						"isCool": true,
+						"type": "sqlNullPosts"
+					}
+				}
+			`))
+		})
+	})
 })

--- a/jsonapi/unmarshal.go
+++ b/jsonapi/unmarshal.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"strings"
 	"time"
+
+	"gopkg.in/guregu/null.v2/zero"
 )
 
 // UnmarshalIdentifier interface to set ID when unmarshalling
@@ -282,7 +284,19 @@ func setFieldValue(field *reflect.Value, value reflect.Value) (err error) {
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		field.SetUint(uint64(value.Float()))
 	default:
-		field.Set(value)
+		// handle zero types from "gopkg.in/guregu/null.v2/zero"
+		switch field.Interface().(type) {
+		case zero.String:
+			field.Set(reflect.ValueOf(zero.StringFrom(value.Interface().(string))))
+		case zero.Float:
+			field.Set(reflect.ValueOf(zero.FloatFrom(value.Interface().(float64))))
+		case zero.Int:
+			field.Set(reflect.ValueOf(zero.IntFrom(int64(value.Interface().(float64)))))
+		case zero.Bool:
+			field.Set(reflect.ValueOf(zero.BoolFrom(value.Interface().(bool))))
+		default:
+			field.Set(value)
+		}
 	}
 
 	return nil

--- a/jsonapi/unmarshal_test.go
+++ b/jsonapi/unmarshal_test.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"time"
 
+	"gopkg.in/guregu/null.v2/zero"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -438,6 +440,38 @@ var _ = Describe("Unmarshal", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(numberPosts)).To(Equal(1))
 			Expect(numberPosts[0].UnsignedNumber).To(Equal(uint64(1337)))
+		})
+	})
+
+	Context("SQL Null-Types", func() {
+		var nullPosts []SqlNullPost
+
+		BeforeEach(func() {
+			nullPosts = []SqlNullPost{}
+		})
+
+		It("correctly unmarshal String, Int64 and Float64", func() {
+			err := UnmarshalFromJSON([]byte(`
+				{
+					"data": {
+						"id": "theID",
+						"title": "Test",
+						"likes": 666,
+						"rating": 66.66,
+						"isCool": true,
+						"type": "sqlNullPosts"
+					}
+				}
+			`), &nullPosts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nullPosts).To(HaveLen(1))
+			Expect(nullPosts[0]).To(Equal(SqlNullPost{
+				ID:     "theID",
+				Title:  zero.StringFrom("Test"),
+				Likes:  zero.IntFrom(666),
+				Rating: zero.FloatFrom(66.66),
+				IsCool: zero.BoolFrom(true),
+			}))
 		})
 	})
 })


### PR DESCRIPTION
This fixes #109 

However I am not very happy with the current unmarshaling in api2go. For new types it is required to implement some interfaces in order for them to be marshalled/unmarshaled:

- json.Marshaler
- json.Unmarshaler

Marshalling is done right in api2go and the implemented interface will be used. Unmarshaling however cannot currently use implemented Unmarshaler interfaces.

I would suggest that we open another issue for this matter and refactor our unmarshaling.

But SQL-Types work for now. Once we refactored unmarshaling, any custom type that implements the interfaces can be used, that will be very cool :) 